### PR TITLE
docs: Missing link about PR Merge Document in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 - [Notion](https://www.notion.so/pesto/Batch-11-project-specs-40cef8d675c04ac0b72a7c2995073781)
 
 ### Instructions
-- Please create a issue first and then attach that issue to the PR, so that every one know what’s the need of the PR. Attaching issues to the PR using github keywords, will close the issues once the PR is merged. More info [here]((https://help.github.com/en/articles/closing-issues-using-keywords)).
+- Please create a issue first and then attach that issue to the PR, so that every one know what’s the need of the PR. Attaching issues to the PR using github keywords, will close the issues once the PR is merged. More info [here](https://help.github.com/en/articles/closing-issues-using-keywords).
 
 - Please follow a common git commit style guide. Somewhat similar to [this guide](https://udacity.github.io/git-styleguide/)
 


### PR DESCRIPTION
# Description

There was PR Merge Document was missing, so i added the relevant link in README.md

Fixes #6

## Type: docs

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules